### PR TITLE
mention grunt-asar in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ asar.createPackage(src, dest, function() {
 
 Please note that there is currently *no* error handling provided!
 
+## Using with grunt
+
+There is also an inofficial grunt plugin to generate asar archives at [bwin/grunt-asar][grunt-asar].
+
 ## Format
 
 Asar uses [Pickle][pickle] to safely serialize binary value to file, there is
@@ -128,3 +132,4 @@ safe to convert `Number` to UINT64.
 
 [pickle]: https://chromium.googlesource.com/chromium/src/+/master/base/pickle.h
 [node-pickle]: https://www.npmjs.org/package/chromium-pickle
+[grunt-asar]: https://github.com/bwin/grunt-asar


### PR DESCRIPTION
Kept it intentionally short.

On #5 it wasn't clear to me if your :+1: was about adding grunt-asar to the readme or the PR itself. Feel free to close if you don't want it mentioned.
