### PR TITLE
drop chromium-pickle dependency. implement reading / writing asar archives in pure JS

### DIFF
--- a/lib/disk.js
+++ b/lib/disk.js
@@ -1,9 +1,9 @@
 var Filesystem = require('./filesystem');
 var fs = require('fs');
-var pickle = require('chromium-pickle');
+var pickleHeader = new Buffer([0x04, 0x00, 0x00, 0x00, 0xfc, 0x00, 0x00, 0x00, 0xf8, 0x00, 0x00, 0x00]);
 
 var writeFileListToStream = function(out, list, cb) {
-  if (list.length == 0) {
+  if (list.length === 0) {
     out.end();
     if ('function' === typeof cb) {
       cb(null);
@@ -17,34 +17,33 @@ var writeFileListToStream = function(out, list, cb) {
 };
 
 module.exports.writeFilesystem = function(dest, filesystem, files, cb) {
-  var headerPickle = pickle.createEmpty();
-  headerPickle.writeString(JSON.stringify(filesystem.header));
-  var headerBuf = headerPickle.toBuffer();
+  var headerBuf = new Buffer(JSON.stringify(filesystem.header), 'utf8');
+  var sizeBuf = new Buffer(4);
 
-  var sizePickle = pickle.createEmpty();
-  sizePickle.writeUInt32(headerBuf.length);
-  var sizeBuf = sizePickle.toBuffer();
+  sizeBuf.writeUInt32LE(headerBuf.length);
 
   var out = fs.createWriteStream(dest);
+  out.write(pickleHeader);
   out.write(sizeBuf);
-  out.write(headerBuf, writeFileListToStream.bind(this, out, files, cb));
+  out.write(headerBuf);
+  out.write(new Buffer([0x00, 0x00]), writeFileListToStream.bind(this, out, files, cb));
 };
 
 module.exports.readArchiveHeader = function(archive) {
   var fd = fs.openSync(archive, 'r');
-  var sizeBuf = new Buffer(8);
-  if (fs.readSync(fd, sizeBuf, 0, 8, null) != 8)
+
+  var sizeBuf = new Buffer(16);
+  if (fs.readSync(fd, sizeBuf, 0, 16, 0) !== 16)
     throw new Error('Unable to read header size');
 
-  var sizePickle = pickle.createFromBuffer(sizeBuf);
-  var size = sizePickle.createIterator().readUInt32();
+  var size = sizeBuf.slice(-4).readUInt32LE();
   var headerBuf = new Buffer(size);
-  if (fs.readSync(fd, headerBuf, 0, size, null) != size)
+
+  if (fs.readSync(fd, headerBuf, 0, size, 16) !== size)
     throw new Error('Unable to read header');
   fs.closeSync(fd);
 
-  var headerPickle = pickle.createFromBuffer(headerBuf);
-  var header = headerPickle.createIterator().readString();
+  var header = headerBuf.toString('utf8');
   return { header: JSON.parse(header), headerSize: size };
 };
 
@@ -63,7 +62,7 @@ module.exports.readFile = function(filesystem, info) {
     // so we short-circuit the read in this case.
     var fd = fs.openSync(filesystem.src, 'r');
     fs.readSync(fd, buffer, 0, info.size,
-                8 + filesystem.headerSize + parseInt(info.offset));
+                18 + filesystem.headerSize + parseInt(info.offset));
     fs.closeSync(fd);
   }
   return buffer;

--- a/lib/disk.js
+++ b/lib/disk.js
@@ -1,6 +1,6 @@
 var Filesystem = require('./filesystem');
+var Header = require('./header');
 var fs = require('fs');
-var pickleHeader = new Buffer([0x04, 0x00, 0x00, 0x00, 0xfc, 0x00, 0x00, 0x00, 0xf8, 0x00, 0x00, 0x00]);
 
 var writeFileListToStream = function(out, list, cb) {
   if (list.length === 0) {
@@ -17,34 +17,13 @@ var writeFileListToStream = function(out, list, cb) {
 };
 
 module.exports.writeFilesystem = function(dest, filesystem, files, cb) {
-  var headerBuf = new Buffer(JSON.stringify(filesystem.header), 'utf8');
-  var sizeBuf = new Buffer(4);
-
-  sizeBuf.writeUInt32LE(headerBuf.length, 0);
-
   var out = fs.createWriteStream(dest);
-  out.write(pickleHeader);
-  out.write(sizeBuf);
-  out.write(headerBuf);
-  out.write(new Buffer([0x00, 0x00]), writeFileListToStream.bind(this, out, files, cb));
+  Header.write(out, filesystem.header, writeFileListToStream.bind(this, out, files, cb));
 };
 
 module.exports.readArchiveHeader = function(archive) {
-  var fd = fs.openSync(archive, 'r');
-
-  var sizeBuf = new Buffer(16);
-  if (fs.readSync(fd, sizeBuf, 0, 16, 0) !== 16)
-    throw new Error('Unable to read header size');
-
-  var size = sizeBuf.slice(-4).readUInt32LE(0);
-  var headerBuf = new Buffer(size);
-
-  if (fs.readSync(fd, headerBuf, 0, size, 16) !== size)
-    throw new Error('Unable to read header');
-  fs.closeSync(fd);
-
-  var header = headerBuf.toString('utf8');
-  return { header: JSON.parse(header), headerSize: size };
+  var header = Header.read(archive);
+  return { header: JSON.parse(header.content), headerSize: header.size };
 };
 
 module.exports.readFilesystem = function(archive) {

--- a/lib/disk.js
+++ b/lib/disk.js
@@ -20,7 +20,7 @@ module.exports.writeFilesystem = function(dest, filesystem, files, cb) {
   var headerBuf = new Buffer(JSON.stringify(filesystem.header), 'utf8');
   var sizeBuf = new Buffer(4);
 
-  sizeBuf.writeUInt32LE(headerBuf.length);
+  sizeBuf.writeUInt32LE(headerBuf.length, 0);
 
   var out = fs.createWriteStream(dest);
   out.write(pickleHeader);
@@ -36,7 +36,7 @@ module.exports.readArchiveHeader = function(archive) {
   if (fs.readSync(fd, sizeBuf, 0, 16, 0) !== 16)
     throw new Error('Unable to read header size');
 
-  var size = sizeBuf.slice(-4).readUInt32LE();
+  var size = sizeBuf.slice(-4).readUInt32LE(0);
   var headerBuf = new Buffer(size);
 
   if (fs.readSync(fd, headerBuf, 0, size, 16) !== size)

--- a/lib/header.js
+++ b/lib/header.js
@@ -1,0 +1,48 @@
+var fs = require('fs');
+var pickleHeader = new Buffer([0x04, 0x00, 0x00, 0x00, 0xfc, 0x00, 0x00, 0x00, 0xf8, 0x00, 0x00, 0x00]);
+var headerTerminator = new Buffer([0x00, 0x00]);
+var pickleSizeOffset = -4;
+
+var getHeaderSize = function(fd) {
+  var sizeBuf = new Buffer(16);
+
+  if (fs.readSync(fd, sizeBuf, 0, 16, 0) !== 16)
+    throw new Error('Unable to read header size');
+
+  return sizeBuf.slice(pickleSizeOffset).readUInt32LE(0);
+};
+
+var getHeaderContent = function(fd, size) {
+  var headerBuf = new Buffer(size);
+  if (fs.readSync(fd, headerBuf, 0, size, 16) !== size)
+    throw new Error('Unable to read header');
+
+  return headerBuf.toString('utf8');
+};
+
+var writeHeader = function(dest, headerBuffer, sizeBuffer, callback) {
+  dest.write(pickleHeader);
+  dest.write(sizeBuffer);
+  dest.write(headerBuffer);
+  dest.write(headerTerminator, callback);
+};
+
+exports.read = function(archive) {
+  var fd = fs.openSync(archive, 'r');
+
+  var size = getHeaderSize(fd);
+  var content = getHeaderContent(fd, size);
+  fs.closeSync(fd);
+
+  return { content: content, size: size };
+};
+
+exports.write = function(dest, header, callback) {
+  var headerBuf = new Buffer(JSON.stringify(header), 'utf8');
+  var headerSize = headerBuf.length;
+  var sizeBuf = new Buffer(4);
+
+  sizeBuf.writeUInt32LE(headerSize, 0);
+
+  writeHeader(dest, headerBuf, sizeBuf, callback);
+};

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "clean": "rm -rf tmp/"
   },
   "dependencies": {
-    "chromium-pickle": "0.1.4",
     "commander": "2.3.0",
     "cuint": "0.1.5",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
As follow-up to https://github.com/atom/asar/issues/16