### PR TITLE
Add new method `createPackageFromFiles` to asar module

### DIFF
--- a/src/asar.coffee
+++ b/src/asar.coffee
@@ -27,71 +27,92 @@ module.exports.createPackageWithOptions = (src, dest, options, callback) ->
 
   crawlFilesystem src, { dot: dot }, (error, filenames, metadata) ->
     return callback(error) if error
-    filesystem = new Filesystem(src)
-    files = []
+    module.exports.createPackageFromFiles src, dest, filenames, metadata, options, callback
+    return
 
-    if options.ordering
-      orderingFiles = fs.readFileSync(options.ordering).toString().split('\n').map (line) ->
-        line = line.split(':').pop() if line.indexOf(':') isnt -1
-        line = line.trim()
-        line = line[1..-1] if line[0] is '/'
-        line
+###
+createPackageFromFiles - Create an asar-archive from a list of filenames
+src: Base path. All files are relative to this.
+dest: Archive filename (& path).
+filenames: Array of filenames relative to src.
+metadata: Object with filenames as keys and {type='directory|file|link', stat: fs.stat} as values. (Optional)
+options: The options.
+callback: The callback function. Accepts (err).
+###
+module.exports.createPackageFromFiles = (src, dest, filenames, metadata, options, callback) ->
+  metadata ?= {}
+  filesystem = new Filesystem(src)
+  files = []
 
-      ordering = []
-      for file in orderingFiles
-        pathComponents = file.split(path.sep)
-        str = src
-        for pathComponent in pathComponents
-          str = path.join(str, pathComponent)
-          ordering.push(str)
+  if options.ordering
+    orderingFiles = fs.readFileSync(options.ordering).toString().split('\n').map (line) ->
+      line = line.split(':').pop() if line.indexOf(':') isnt -1
+      line = line.trim()
+      line = line[1..-1] if line[0] is '/'
+      line
 
-      filenamesSorted = []
-      missing = 0
-      total = filenames.length
+    ordering = []
+    for file in orderingFiles
+      pathComponents = file.split(path.sep)
+      str = src
+      for pathComponent in pathComponents
+        str = path.join(str, pathComponent)
+        ordering.push(str)
 
-      for file in ordering
-        if filenamesSorted.indexOf(file) is -1 and filenames.indexOf(file) isnt -1
-          filenamesSorted.push(file)
+    filenamesSorted = []
+    missing = 0
+    total = filenames.length
 
-      for file in filenames
-        if filenamesSorted.indexOf(file) is -1
-          filenamesSorted.push(file)
-          missing += 1
+    for file in ordering
+      if filenamesSorted.indexOf(file) is -1 and filenames.indexOf(file) isnt -1
+        filenamesSorted.push(file)
 
-      console.log("Ordering file has #{(total - missing) / total * 100}% coverage.")
-    else
-      filenamesSorted = filenames
+    for file in filenames
+      if filenamesSorted.indexOf(file) is -1
+        filenamesSorted.push(file)
+        missing += 1
 
-    for filename in filenamesSorted
-      file = metadata[filename]
-      switch file.type
-        when 'directory'
-          shouldUnpack =
-            if options.unpackDir
-              isUnpackDir path.relative(src, filename), options.unpackDir
-            else
-              false
-          filesystem.insertDirectory filename, shouldUnpack
-        when 'file'
-          shouldUnpack = false
-          if options.unpack
-            shouldUnpack = minimatch filename, options.unpack, matchBase: true
-          if not shouldUnpack and options.unpackDir
-            dirName = path.relative src, path.dirname(filename)
-            shouldUnpack = isUnpackDir dirName, options.unpackDir
-          files.push filename: filename, unpack: shouldUnpack
-          filesystem.insertFile filename, shouldUnpack, file.stat
-        when 'link'
-          filesystem.insertLink filename, file.stat
+    console.log("Ordering file has #{(total - missing) / total * 100}% coverage.")
+  else
+    filenamesSorted = filenames
 
-    mkdirp path.dirname(dest), (error) ->
+  for filename in filenamesSorted
+    file = metadata[filename]
+    unless file
+      stat = fs.lstatSync filename
+      type = 'directory' if stat.isDirectory()
+      type = 'file' if stat.isFile()
+      type = 'link' if stat.isSymbolicLink()
+      file = {stat, type}
+
+    switch file.type
+      when 'directory'
+        shouldUnpack =
+          if options.unpackDir
+            isUnpackDir path.relative(src, filename), options.unpackDir
+          else
+            false
+        filesystem.insertDirectory filename, shouldUnpack
+      when 'file'
+        shouldUnpack = false
+        if options.unpack
+          shouldUnpack = minimatch filename, options.unpack, matchBase: true
+        if not shouldUnpack and options.unpackDir
+          dirName = path.relative src, path.dirname(filename)
+          shouldUnpack = isUnpackDir dirName, options.unpackDir
+        files.push filename: filename, unpack: shouldUnpack
+        filesystem.insertFile filename, shouldUnpack, file.stat
+      when 'link'
+        filesystem.insertLink filename, file.stat
+
+  mkdirp path.dirname(dest), (error) ->
+    return callback(error) if error
+    disk.writeFilesystem dest, filesystem, files, (error) ->
       return callback(error) if error
-      disk.writeFilesystem dest, filesystem, files, (error) ->
-        return callback(error) if error
-        if options.snapshot
-          createSnapshot src, dest, filenames, metadata, options, callback
-        else
-          callback null
+      if options.snapshot
+        createSnapshot src, dest, filenames, metadata, options, callback
+      else
+        callback null
 
 module.exports.statFile = (archive, filename, followLinks) ->
   filesystem = disk.readFilesystemSync archive


### PR DESCRIPTION
Hi Cheng, haven't worked on (or with asar) for quite some time. But I still have a grunt and a gulp plugin for it on npm which need to be updated *badly*.

This is just another method to create an archive. This is helpful for grunt and gulp, when some other code already did the globbing.

The code didn't change that much, as GitHub makes it seem. Most lines have just one level less indentation.