### PR TITLE
Update package.json - refer to license by SPDX license ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,7 @@
   "bin": {
     "asar": "bin/asar"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/atom/asar/raw/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "homepage": "https://github.com/atom/asar",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Stop `npm` crying... (by using a SPDX license ID in package.json)
~~```npm WARN package.json asar@0.9.1 No license field.```~~