### PR TITLE
fix: add path validation to prevent directory traversal attacks

### DIFF
--- a/src/asar.ts
+++ b/src/asar.ts
@@ -3,6 +3,7 @@ import { minimatch } from 'minimatch';
 
 import { wrappedFs as fs } from './wrapped-fs.js';
 import { Filesystem, FilesystemEntry } from './filesystem.js';
+import { ensureWithin } from './path-validation.js';
 import {
   BasicFilesArray,
   BasicStreamArray,
@@ -388,11 +389,8 @@ export function extractAll(archivePath: string, dest: string) {
   for (const fullPath of filenames) {
     // Remove leading slash
     const filename = fullPath.substr(1);
-    const destFilename = path.join(dest, filename);
+    const destFilename = ensureWithin(dest, filename);
     const file = filesystem.getFile(filename, followLinks);
-    if (path.relative(dest, destFilename).startsWith('..')) {
-      throw new Error(`${fullPath}: file "${destFilename}" writes out of the package`);
-    }
     if ('files' in file) {
       // it's a directory, create it and continue with the next entry
       fs.mkdirpSync(destFilename);

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -3,6 +3,7 @@ import { wrappedFs as fs } from './wrapped-fs.js';
 import { Pickle } from './pickle.js';
 import { Filesystem, FilesystemFileEntry } from './filesystem.js';
 import { CrawledFileType } from './crawlfs.js';
+import { ensureWithin } from './path-validation.js';
 import { Stats } from 'node:fs';
 import stream from 'node:stream/promises';
 
@@ -221,11 +222,7 @@ export function readFileSync(filesystem: Filesystem, filename: string, info: Fil
   if (info.unpacked) {
     // it's an unpacked file, copy it.
     const unpackedDir = `${filesystem.getRootPath()}.unpacked`;
-    const resolvedPath = path.resolve(unpackedDir, filename);
-    if (!resolvedPath.startsWith(unpackedDir + path.sep) && resolvedPath !== unpackedDir) {
-      throw new Error(`File "${filename}" traverses outside the unpacked directory`);
-    }
-    buffer = fs.readFileSync(resolvedPath);
+    buffer = fs.readFileSync(ensureWithin(unpackedDir, filename));
   } else {
     // Node throws an exception when reading 0 bytes into a 0-size buffer,
     // so we short-circuit the read in this case.

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -220,7 +220,12 @@ export function readFileSync(filesystem: Filesystem, filename: string, info: Fil
   }
   if (info.unpacked) {
     // it's an unpacked file, copy it.
-    buffer = fs.readFileSync(path.join(`${filesystem.getRootPath()}.unpacked`, filename));
+    const unpackedDir = `${filesystem.getRootPath()}.unpacked`;
+    const resolvedPath = path.resolve(unpackedDir, filename);
+    if (!resolvedPath.startsWith(unpackedDir + path.sep) && resolvedPath !== unpackedDir) {
+      throw new Error(`File "${filename}" traverses outside the unpacked directory`);
+    }
+    buffer = fs.readFileSync(resolvedPath);
   } else {
     // Node throws an exception when reading 0 bytes into a 0-size buffer,
     // so we short-circuit the read in this case.

--- a/src/path-validation.ts
+++ b/src/path-validation.ts
@@ -1,0 +1,17 @@
+import path from 'node:path';
+
+/**
+ * Validates that a resolved child path is strictly within a container directory.
+ * Uses path.resolve (not realpath) so it works before paths exist on disk.
+ * Throws if the resolved path escapes the container via traversal sequences.
+ */
+export function ensureWithin(container: string, filePath: string): string {
+  const resolvedContainer = path.resolve(container);
+  const resolvedPath = path.resolve(resolvedContainer, filePath);
+  if (!resolvedPath.startsWith(resolvedContainer + path.sep) && resolvedPath !== resolvedContainer) {
+    throw new Error(
+      `Path "${filePath}" resolves to "${resolvedPath}" which is outside "${resolvedContainer}"`,
+    );
+  }
+  return resolvedPath;
+}

--- a/src/path-validation.ts
+++ b/src/path-validation.ts
@@ -8,7 +8,10 @@ import path from 'node:path';
 export function ensureWithin(container: string, filePath: string): string {
   const resolvedContainer = path.resolve(container);
   const resolvedPath = path.resolve(resolvedContainer, filePath);
-  if (!resolvedPath.startsWith(resolvedContainer + path.sep) && resolvedPath !== resolvedContainer) {
+  if (
+    !resolvedPath.startsWith(resolvedContainer + path.sep) &&
+    resolvedPath !== resolvedContainer
+  ) {
     throw new Error(
       `Path "${filePath}" resolves to "${resolvedPath}" which is outside "${resolvedContainer}"`,
     );

--- a/test/path-validation-spec.ts
+++ b/test/path-validation-spec.ts
@@ -1,0 +1,33 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { ensureWithin } from '../src/path-validation.js';
+
+describe('ensureWithin', () => {
+  const container = '/archive.asar.unpacked';
+
+  it('should return resolved path for valid filenames', () => {
+    expect(ensureWithin(container, 'file.txt')).toBe(
+      path.resolve(container, 'file.txt'),
+    );
+    expect(ensureWithin(container, 'sub/dir/file.txt')).toBe(
+      path.resolve(container, 'sub/dir/file.txt'),
+    );
+  });
+
+  it('should throw for path traversal with ../', () => {
+    expect(() => ensureWithin(container, '../etc/passwd')).toThrow('outside');
+    expect(() => ensureWithin(container, '../../etc/passwd')).toThrow('outside');
+    expect(() => ensureWithin(container, 'sub/../../etc/passwd')).toThrow('outside');
+  });
+
+  it('should allow .. that stays within container', () => {
+    expect(ensureWithin(container, 'sub/../file.txt')).toBe(
+      path.resolve(container, 'file.txt'),
+    );
+  });
+
+  it('should throw for absolute paths outside container', () => {
+    expect(() => ensureWithin(container, '/etc/passwd')).toThrow('outside');
+  });
+});

--- a/test/path-validation-spec.ts
+++ b/test/path-validation-spec.ts
@@ -7,9 +7,7 @@ describe('ensureWithin', () => {
   const container = '/archive.asar.unpacked';
 
   it('should return resolved path for valid filenames', () => {
-    expect(ensureWithin(container, 'file.txt')).toBe(
-      path.resolve(container, 'file.txt'),
-    );
+    expect(ensureWithin(container, 'file.txt')).toBe(path.resolve(container, 'file.txt'));
     expect(ensureWithin(container, 'sub/dir/file.txt')).toBe(
       path.resolve(container, 'sub/dir/file.txt'),
     );
@@ -22,9 +20,7 @@ describe('ensureWithin', () => {
   });
 
   it('should allow .. that stays within container', () => {
-    expect(ensureWithin(container, 'sub/../file.txt')).toBe(
-      path.resolve(container, 'file.txt'),
-    );
+    expect(ensureWithin(container, 'sub/../file.txt')).toBe(path.resolve(container, 'file.txt'));
   });
 
   it('should throw for absolute paths outside container', () => {


### PR DESCRIPTION
## Summary
This PR adds a new `ensureWithin` function to validate that resolved file paths stay within their intended container directory, preventing directory traversal attacks. The function is integrated into the archive extraction and unpacked file reading workflows.

## Key Changes
- **New module `src/path-validation.ts`**: Introduces `ensureWithin()` function that validates a child path is strictly contained within a container directory using `path.resolve()` (not `realpath`) to work with paths before they exist on disk
- **Updated `src/asar.ts`**: Replaces manual path traversal check in `extractAll()` with `ensureWithin()` for cleaner, more robust validation
- **Updated `src/disk.ts`**: Applies `ensureWithin()` validation when reading unpacked files to ensure the filename doesn't escape the unpacked directory
- **New test suite `test/path-validation-spec.ts`**: Comprehensive tests covering valid paths, path traversal attempts with `../`, edge cases where `..` stays within container, and absolute paths outside the container

## Implementation Details
- The validation uses `path.resolve()` to normalize paths before checking boundaries, making it work with non-existent paths
- Checks that the resolved path either starts with `container + path.sep` or equals the container exactly
- Throws descriptive errors when paths attempt to escape the container
- Replaces the previous `path.relative()` based check which was less reliable

https://claude.ai/code/session_01Ad3VMQ7rBvae7tfwtxgmgx