### PR TITLE
fix: add header validation for ASAR archives

### DIFF
--- a/src/disk.ts
+++ b/src/disk.ts
@@ -8,6 +8,126 @@ import stream from 'node:stream/promises';
 
 let filesystemCache: Record<string, Filesystem | undefined> = Object.create(null);
 
+class HeaderValidationError extends Error {
+  constructor(path: string, message: string) {
+    super(`Invalid archive header at "${path}": ${message}`);
+    this.name = 'HeaderValidationError';
+  }
+}
+
+function validateFileEntry(entry: Record<string, unknown>, entryPath: string): void {
+  if (typeof entry.offset !== 'string') {
+    throw new HeaderValidationError(entryPath, `"offset" must be a string, got ${typeof entry.offset}`);
+  }
+  if (!/^\d+$/.test(entry.offset)) {
+    throw new HeaderValidationError(entryPath, `"offset" must be a numeric string, got "${entry.offset}"`);
+  }
+  if (typeof entry.size !== 'number' || !Number.isFinite(entry.size) || entry.size < 0) {
+    throw new HeaderValidationError(entryPath, `"size" must be a non-negative number, got ${JSON.stringify(entry.size)}`);
+  }
+  if (entry.unpacked !== undefined && typeof entry.unpacked !== 'boolean') {
+    throw new HeaderValidationError(entryPath, `"unpacked" must be a boolean, got ${typeof entry.unpacked}`);
+  }
+  if (entry.executable !== undefined && typeof entry.executable !== 'boolean') {
+    throw new HeaderValidationError(entryPath, `"executable" must be a boolean, got ${typeof entry.executable}`);
+  }
+  if (entry.integrity !== undefined) {
+    validateIntegrity(entry.integrity, entryPath);
+  }
+}
+
+function validateUnpackedFileEntry(entry: Record<string, unknown>, entryPath: string): void {
+  if (typeof entry.size !== 'number' || !Number.isFinite(entry.size) || entry.size < 0) {
+    throw new HeaderValidationError(entryPath, `"size" must be a non-negative number, got ${JSON.stringify(entry.size)}`);
+  }
+  if (entry.unpacked !== true) {
+    throw new HeaderValidationError(entryPath, `"unpacked" must be true for unpacked file entries`);
+  }
+  if (entry.executable !== undefined && typeof entry.executable !== 'boolean') {
+    throw new HeaderValidationError(entryPath, `"executable" must be a boolean, got ${typeof entry.executable}`);
+  }
+  if (entry.integrity !== undefined) {
+    validateIntegrity(entry.integrity, entryPath);
+  }
+}
+
+function validateIntegrity(integrity: unknown, entryPath: string): void {
+  if (typeof integrity !== 'object' || integrity === null || Array.isArray(integrity)) {
+    throw new HeaderValidationError(entryPath, `"integrity" must be an object`);
+  }
+  const rec = integrity as Record<string, unknown>;
+  if (typeof rec.algorithm !== 'string') {
+    throw new HeaderValidationError(entryPath, `"integrity.algorithm" must be a string`);
+  }
+  if (typeof rec.hash !== 'string') {
+    throw new HeaderValidationError(entryPath, `"integrity.hash" must be a string`);
+  }
+  if (typeof rec.blockSize !== 'number' || !Number.isFinite(rec.blockSize) || rec.blockSize <= 0) {
+    throw new HeaderValidationError(entryPath, `"integrity.blockSize" must be a positive number`);
+  }
+  if (!Array.isArray(rec.blocks)) {
+    throw new HeaderValidationError(entryPath, `"integrity.blocks" must be an array`);
+  }
+  for (let i = 0; i < rec.blocks.length; i++) {
+    if (typeof rec.blocks[i] !== 'string') {
+      throw new HeaderValidationError(entryPath, `"integrity.blocks[${i}]" must be a string`);
+    }
+  }
+}
+
+function validateLinkEntry(entry: Record<string, unknown>, entryPath: string): void {
+  if (typeof entry.link !== 'string') {
+    throw new HeaderValidationError(entryPath, `"link" must be a string, got ${typeof entry.link}`);
+  }
+  if (entry.link.length === 0) {
+    throw new HeaderValidationError(entryPath, `"link" must not be empty`);
+  }
+}
+
+function validateDirectoryEntry(entry: Record<string, unknown>, entryPath: string): void {
+  if (typeof entry.files !== 'object' || entry.files === null || Array.isArray(entry.files)) {
+    throw new HeaderValidationError(entryPath, `"files" must be a plain object`);
+  }
+  const files = entry.files as Record<string, unknown>;
+  for (const [name, child] of Object.entries(files)) {
+    if (name.includes('/') || name.includes('\\') || name === '.' || name === '..') {
+      throw new HeaderValidationError(entryPath, `invalid entry name "${name}"`);
+    }
+    const childPath = entryPath === '/' ? `/${name}` : `${entryPath}/${name}`;
+    validateHeaderEntry(child, childPath);
+  }
+}
+
+function validateHeaderEntry(entry: unknown, entryPath: string): void {
+  if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+    throw new HeaderValidationError(entryPath, 'entry must be an object');
+  }
+  const rec = entry as Record<string, unknown>;
+
+  if ('link' in rec) {
+    validateLinkEntry(rec, entryPath);
+  } else if ('files' in rec) {
+    validateDirectoryEntry(rec, entryPath);
+  } else if ('offset' in rec) {
+    validateFileEntry(rec, entryPath);
+  } else if ('unpacked' in rec && rec.unpacked === true && 'size' in rec) {
+    validateUnpackedFileEntry(rec, entryPath);
+  } else {
+    throw new HeaderValidationError(entryPath, 'entry must be a directory (with "files"), a file (with "offset" or "unpacked"), or a link (with "link")');
+  }
+}
+
+export function validateHeader(header: unknown): void {
+  if (typeof header !== 'object' || header === null || Array.isArray(header)) {
+    throw new HeaderValidationError('/', 'header must be an object');
+  }
+  const rec = header as Record<string, unknown>;
+  if (!('files' in rec)) {
+    throw new HeaderValidationError('/', 'root header must be a directory with a "files" property');
+  }
+  validateDirectoryEntry(rec, '/');
+}
+
 async function copyFile(dest: string, src: string, filename: string) {
   const srcFile = path.join(src, filename);
   const targetFile = path.join(dest, filename);
@@ -188,7 +308,9 @@ export function readArchiveHeaderSync(archivePath: string): ArchiveHeader {
 
   const headerPickle = Pickle.createFromBuffer(headerBuf);
   const header = headerPickle.createIterator().readString();
-  return { headerString: header, header: JSON.parse(header), headerSize: size };
+  const parsedHeader = JSON.parse(header);
+  validateHeader(parsedHeader);
+  return { headerString: header, header: parsedHeader, headerSize: size };
 }
 
 export function readFilesystemSync(archivePath: string) {

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -17,19 +17,34 @@ class HeaderValidationError extends Error {
 
 function validateFileEntry(entry: Record<string, unknown>, entryPath: string): void {
   if (typeof entry.offset !== 'string') {
-    throw new HeaderValidationError(entryPath, `"offset" must be a string, got ${typeof entry.offset}`);
+    throw new HeaderValidationError(
+      entryPath,
+      `"offset" must be a string, got ${typeof entry.offset}`,
+    );
   }
   if (!/^\d+$/.test(entry.offset)) {
-    throw new HeaderValidationError(entryPath, `"offset" must be a numeric string, got "${entry.offset}"`);
+    throw new HeaderValidationError(
+      entryPath,
+      `"offset" must be a numeric string, got "${entry.offset}"`,
+    );
   }
   if (typeof entry.size !== 'number' || !Number.isFinite(entry.size) || entry.size < 0) {
-    throw new HeaderValidationError(entryPath, `"size" must be a non-negative number, got ${JSON.stringify(entry.size)}`);
+    throw new HeaderValidationError(
+      entryPath,
+      `"size" must be a non-negative number, got ${JSON.stringify(entry.size)}`,
+    );
   }
   if (entry.unpacked !== undefined && typeof entry.unpacked !== 'boolean') {
-    throw new HeaderValidationError(entryPath, `"unpacked" must be a boolean, got ${typeof entry.unpacked}`);
+    throw new HeaderValidationError(
+      entryPath,
+      `"unpacked" must be a boolean, got ${typeof entry.unpacked}`,
+    );
   }
   if (entry.executable !== undefined && typeof entry.executable !== 'boolean') {
-    throw new HeaderValidationError(entryPath, `"executable" must be a boolean, got ${typeof entry.executable}`);
+    throw new HeaderValidationError(
+      entryPath,
+      `"executable" must be a boolean, got ${typeof entry.executable}`,
+    );
   }
   if (entry.integrity !== undefined) {
     validateIntegrity(entry.integrity, entryPath);
@@ -38,13 +53,19 @@ function validateFileEntry(entry: Record<string, unknown>, entryPath: string): v
 
 function validateUnpackedFileEntry(entry: Record<string, unknown>, entryPath: string): void {
   if (typeof entry.size !== 'number' || !Number.isFinite(entry.size) || entry.size < 0) {
-    throw new HeaderValidationError(entryPath, `"size" must be a non-negative number, got ${JSON.stringify(entry.size)}`);
+    throw new HeaderValidationError(
+      entryPath,
+      `"size" must be a non-negative number, got ${JSON.stringify(entry.size)}`,
+    );
   }
   if (entry.unpacked !== true) {
     throw new HeaderValidationError(entryPath, `"unpacked" must be true for unpacked file entries`);
   }
   if (entry.executable !== undefined && typeof entry.executable !== 'boolean') {
-    throw new HeaderValidationError(entryPath, `"executable" must be a boolean, got ${typeof entry.executable}`);
+    throw new HeaderValidationError(
+      entryPath,
+      `"executable" must be a boolean, got ${typeof entry.executable}`,
+    );
   }
   if (entry.integrity !== undefined) {
     validateIntegrity(entry.integrity, entryPath);
@@ -113,7 +134,10 @@ function validateHeaderEntry(entry: unknown, entryPath: string): void {
   } else if ('unpacked' in rec && rec.unpacked === true && 'size' in rec) {
     validateUnpackedFileEntry(rec, entryPath);
   } else {
-    throw new HeaderValidationError(entryPath, 'entry must be a directory (with "files"), a file (with "offset" or "unpacked"), or a link (with "link")');
+    throw new HeaderValidationError(
+      entryPath,
+      'entry must be a directory (with "files"), a file (with "offset" or "unpacked"), or a link (with "link")',
+    );
   }
 }
 

--- a/test/header-validation-spec.ts
+++ b/test/header-validation-spec.ts
@@ -1,0 +1,369 @@
+import { describe, it, expect } from 'vitest';
+import { validateHeader } from '../src/disk.js';
+
+describe('validateHeader', () => {
+  it('should accept a valid header with files', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          'index.js': {
+            offset: '0',
+            size: 100,
+            integrity: {
+              algorithm: 'SHA256',
+              hash: 'abc123',
+              blockSize: 4194304,
+              blocks: ['abc123'],
+            },
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it('should accept a valid header with nested directories', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          src: {
+            files: {
+              'main.js': {
+                offset: '0',
+                size: 50,
+              },
+            },
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it('should accept a valid header with link entries', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          'link.js': {
+            link: 'target.js',
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it('should accept a valid header with unpacked file entries', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          'native.node': {
+            unpacked: true,
+            size: 1024,
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it('should accept empty directory', () => {
+    expect(() => validateHeader({ files: {} })).not.toThrow();
+  });
+
+  it('should reject non-object header', () => {
+    expect(() => validateHeader('string')).toThrow('header must be an object');
+    expect(() => validateHeader(null)).toThrow('header must be an object');
+    expect(() => validateHeader([])).toThrow('header must be an object');
+    expect(() => validateHeader(42)).toThrow('header must be an object');
+  });
+
+  it('should reject header without files property', () => {
+    expect(() => validateHeader({})).toThrow('root header must be a directory');
+  });
+
+  it('should reject file entry with non-string offset', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          'bad.js': {
+            offset: 123,
+            size: 100,
+          },
+        },
+      }),
+    ).toThrow('"offset" must be a string');
+  });
+
+  it('should reject file entry with non-numeric offset string', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          'bad.js': {
+            offset: 'abc',
+            size: 100,
+          },
+        },
+      }),
+    ).toThrow('"offset" must be a numeric string');
+  });
+
+  it('should reject file entry with non-number size', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          'bad.js': {
+            offset: '0',
+            size: '100',
+          },
+        },
+      }),
+    ).toThrow('"size" must be a non-negative number');
+  });
+
+  it('should reject file entry with negative size', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          'bad.js': {
+            offset: '0',
+            size: -1,
+          },
+        },
+      }),
+    ).toThrow('"size" must be a non-negative number');
+  });
+
+  it('should reject file entry with non-boolean unpacked', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          'bad.js': {
+            offset: '0',
+            size: 100,
+            unpacked: 'yes',
+          },
+        },
+      }),
+    ).toThrow('"unpacked" must be a boolean');
+  });
+
+  it('should reject file entry with non-boolean executable', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          'bad.js': {
+            offset: '0',
+            size: 100,
+            executable: 1,
+          },
+        },
+      }),
+    ).toThrow('"executable" must be a boolean');
+  });
+
+  it('should reject link entry with non-string link', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          'bad-link': {
+            link: 123,
+          },
+        },
+      }),
+    ).toThrow('"link" must be a string');
+  });
+
+  it('should reject link entry with empty link', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          'bad-link': {
+            link: '',
+          },
+        },
+      }),
+    ).toThrow('"link" must not be empty');
+  });
+
+  it('should reject directory entry with non-object files', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          dir: {
+            files: 'not-an-object',
+          },
+        },
+      }),
+    ).toThrow('"files" must be a plain object');
+  });
+
+  it('should reject directory entry with array files', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          dir: {
+            files: [],
+          },
+        },
+      }),
+    ).toThrow('"files" must be a plain object');
+  });
+
+  it('should reject entry names with path separators', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          'a/b': {
+            offset: '0',
+            size: 100,
+          },
+        },
+      }),
+    ).toThrow('invalid entry name');
+  });
+
+  it('should reject dot-dot entry names', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          '..': {
+            files: {},
+          },
+        },
+      }),
+    ).toThrow('invalid entry name');
+  });
+
+  it('should reject entries that are not directory, file, or link', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          mystery: {
+            something: 'weird',
+          },
+        },
+      }),
+    ).toThrow('entry must be a directory');
+  });
+
+  it('should reject non-object entries', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          bad: 'string',
+        },
+      }),
+    ).toThrow('entry must be an object');
+  });
+
+  it('should reject invalid integrity object', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          'bad.js': {
+            offset: '0',
+            size: 100,
+            integrity: 'not-an-object',
+          },
+        },
+      }),
+    ).toThrow('"integrity" must be an object');
+  });
+
+  it('should reject integrity with non-string hash', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          'bad.js': {
+            offset: '0',
+            size: 100,
+            integrity: {
+              algorithm: 'SHA256',
+              hash: 123,
+              blockSize: 4194304,
+              blocks: [],
+            },
+          },
+        },
+      }),
+    ).toThrow('"integrity.hash" must be a string');
+  });
+
+  it('should reject integrity with non-array blocks', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          'bad.js': {
+            offset: '0',
+            size: 100,
+            integrity: {
+              algorithm: 'SHA256',
+              hash: 'abc',
+              blockSize: 4194304,
+              blocks: 'not-an-array',
+            },
+          },
+        },
+      }),
+    ).toThrow('"integrity.blocks" must be an array');
+  });
+
+  it('should reject integrity with non-string block entries', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          'bad.js': {
+            offset: '0',
+            size: 100,
+            integrity: {
+              algorithm: 'SHA256',
+              hash: 'abc',
+              blockSize: 4194304,
+              blocks: [123],
+            },
+          },
+        },
+      }),
+    ).toThrow('"integrity.blocks[0]" must be a string');
+  });
+
+  it('should reject integrity with invalid blockSize', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          'bad.js': {
+            offset: '0',
+            size: 100,
+            integrity: {
+              algorithm: 'SHA256',
+              hash: 'abc',
+              blockSize: 0,
+              blocks: [],
+            },
+          },
+        },
+      }),
+    ).toThrow('"integrity.blockSize" must be a positive number');
+  });
+
+  it('should include the entry path in error messages', () => {
+    expect(() =>
+      validateHeader({
+        files: {
+          src: {
+            files: {
+              'bad.js': {
+                offset: 999,
+                size: 100,
+              },
+            },
+          },
+        },
+      }),
+    ).toThrow('/src/bad.js');
+  });
+
+  it('should validate existing asar headers succeed', async () => {
+    // readArchiveHeaderSync calls validateHeader internally,
+    // so valid archives should parse without errors
+    const { readArchiveHeaderSync } = await import('../src/disk.js');
+    expect(() => readArchiveHeaderSync('test/expected/packthis.asar')).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds comprehensive validation for ASAR archive headers to ensure data integrity and prevent parsing errors from malformed archives.

## Key Changes
- **New `validateHeader()` function**: Validates the entire ASAR header structure, including all nested entries and their properties
- **Entry type validation**: Distinguishes between three entry types (files, directories, and links) and validates each according to its specific requirements
- **Property validation**: Enforces type checking and constraints for all header properties:
  - File entries: `offset` (numeric string), `size` (non-negative number), `unpacked` (boolean), `executable` (boolean), `integrity` (object)
  - Directory entries: `files` (plain object with recursively validated children)
  - Link entries: `link` (non-empty string)
  - Integrity objects: `algorithm`, `hash`, `blockSize` (positive number), `blocks` (string array)
- **Path validation**: Prevents invalid entry names containing path separators (`/`, `\`) or special names (`.`, `..`)
- **Error reporting**: Custom `HeaderValidationError` class provides detailed error messages with entry paths for easier debugging
- **Integration**: `readArchiveHeaderSync()` now validates headers before returning them
- **Comprehensive test suite**: 30+ test cases covering valid headers, all validation rules, and error conditions

## Implementation Details
- Validation is performed recursively to handle nested directory structures
- Entry paths are tracked and included in error messages for precise error location reporting
- The validation distinguishes between packed files (with `offset`) and unpacked files (with `unpacked: true`)
- All numeric validations use `Number.isFinite()` to reject NaN and Infinity values

https://claude.ai/code/session_01QStMM3UdYbuNVRxunopW1o