### PR TITLE
fix: improve symlink validation to prevent directory traversal attacks

### DIFF
--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -203,7 +203,7 @@ export class Filesystem {
     src: string = fs.realpathSync(this.src),
   ) {
     const link = this.resolveLink(src, parentPath, symlink);
-    if (link.startsWith('..')) {
+    if (path.isAbsolute(link) || path.normalize(link).startsWith('..')) {
       throw new Error(`${p}: file "${link}" links out of the package`);
     }
     const node = this.searchNodeFromPath(p) as FilesystemLinkEntry;

--- a/test/filesystem-spec.ts
+++ b/test/filesystem-spec.ts
@@ -228,4 +228,64 @@ describe('filesystem', () => {
       expect('link' in result).toBe(true);
     });
   });
+
+  describe('insertLink symlink validation', () => {
+    it('should reject symlinks that resolve outside the package via deeply nested traversal', () => {
+      const src = '/package';
+      const filesystem = new Filesystem(src);
+      expect(() => {
+        filesystem.insertLink(
+          path.join(src, 'a', 'b', 'link'),
+          false,
+          path.join(src, 'a', 'b'), // parentPath
+          '../../../etc/passwd', // symlink traverses out of /package
+          src,
+        );
+      }).toThrow('links out of the package');
+    });
+
+    it('should reject symlinks that traverse out via normalized path (e.g. valid/../../../etc/passwd)', () => {
+      const src = '/package';
+      const filesystem = new Filesystem(src);
+      expect(() => {
+        filesystem.insertLink(
+          path.join(src, 'link'),
+          false,
+          path.join(src, 'subdir'), // parentPath
+          'valid/../../../etc/passwd', // symlink that normalizes to ../../etc/passwd
+          src,
+        );
+      }).toThrow('links out of the package');
+    });
+
+    it('should reject symlinks that directly traverse out with ..', () => {
+      const src = '/package';
+      const filesystem = new Filesystem(src);
+      expect(() => {
+        filesystem.insertLink(path.join(src, 'link'), false, src, '../../etc/passwd', src);
+      }).toThrow('links out of the package');
+    });
+
+    it('should allow symlinks that stay within the package', () => {
+      const src = '/package';
+      const filesystem = new Filesystem(src);
+      expect(() => {
+        filesystem.insertLink(
+          path.join(src, 'link'),
+          false,
+          path.join(src, 'subdir'), // parentPath
+          '../other-file.txt', // resolves to /package/other-file.txt
+          src,
+        );
+      }).not.toThrow();
+    });
+
+    it('should allow symlinks to files in subdirectories', () => {
+      const src = '/package';
+      const filesystem = new Filesystem(src);
+      expect(() => {
+        filesystem.insertLink(path.join(src, 'link'), false, src, 'subdir/file.txt', src);
+      }).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Enhanced symlink validation in the `Filesystem.insertLink()` method to properly detect and reject symlinks that attempt to traverse outside the package directory, including cases with normalized paths containing `..` sequences.

## Key Changes
- Updated symlink validation logic to check for both absolute paths and normalized relative paths that start with `..`
- Changed validation from `link.startsWith('..')` to `path.isAbsolute(link) || path.normalize(link).startsWith('..')`
- Added comprehensive test coverage for symlink validation including:
  - Deeply nested directory traversal attempts (e.g., `../../../etc/passwd`)
  - Normalized paths that resolve outside the package (e.g., `valid/../../../etc/passwd`)
  - Direct parent directory traversal (e.g., `../../etc/passwd`)
  - Valid symlinks that stay within the package boundaries
  - Symlinks to subdirectory files

## Implementation Details
The fix addresses a security vulnerability where symlinks with normalized paths containing `..` sequences could bypass the original validation. By normalizing the symlink path before checking if it starts with `..`, the validation now properly catches all attempts to traverse outside the package root, regardless of how the path is constructed.

https://claude.ai/code/session_01ToEd41UYKFKYRimu6uxnPx