### PR TITLE
fix: add circular symlink detection and depth limit protection

### DIFF
--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -7,6 +7,7 @@ import { wrappedFs as fs } from './wrapped-fs.js';
 import { CrawledFileType } from './crawlfs.js';
 
 const UINT32_MAX = 2 ** 32 - 1;
+const SYMLINK_MAX_DEPTH = 40; // matches Linux SYMLOOP_MAX
 
 // Files smaller than this use buffer-based integrity hashing (avoids stream overhead).
 // Files larger than this use streaming to avoid holding large buffers in memory.
@@ -241,11 +242,24 @@ export class Filesystem {
     return files;
   }
 
-  getNode(p: string, followLinks: boolean = true): FilesystemEntry {
+  getNode(
+    p: string,
+    followLinks: boolean = true,
+    depth: number = 0,
+    visited: Set<string> = new Set(),
+  ): FilesystemEntry {
     const node = this.searchNodeFromDirectory(path.dirname(p));
     const name = path.basename(p);
     if ('link' in node && followLinks) {
-      return this.getNode(path.join(node.link, name));
+      const resolvedPath = path.join(node.link, name);
+      if (visited.has(resolvedPath)) {
+        throw new Error(`"${p}": circular symlink detected at "${resolvedPath}"`);
+      }
+      if (depth >= SYMLINK_MAX_DEPTH) {
+        throw new Error(`"${p}": too many levels of symbolic links (>${SYMLINK_MAX_DEPTH})`);
+      }
+      visited.add(resolvedPath);
+      return this.getNode(resolvedPath, followLinks, depth + 1, visited);
     }
     if (name) {
       return (node as FilesystemDirectoryEntry).files[name];
@@ -254,8 +268,13 @@ export class Filesystem {
     }
   }
 
-  getFile(p: string, followLinks: boolean = true): FilesystemEntry {
-    const info = this.getNode(p, followLinks);
+  getFile(
+    p: string,
+    followLinks: boolean = true,
+    depth: number = 0,
+    visited: Set<string> = new Set(),
+  ): FilesystemEntry {
+    const info = this.getNode(p, followLinks, depth, visited);
 
     if (!info) {
       throw new Error(`"${p}" was not found in this archive`);
@@ -263,7 +282,15 @@ export class Filesystem {
 
     // if followLinks is false we don't resolve symlinks
     if ('link' in info && followLinks) {
-      return this.getFile(info.link, followLinks);
+      const link = (info as FilesystemLinkEntry).link;
+      if (visited.has(link)) {
+        throw new Error(`"${p}": circular symlink detected at "${link}"`);
+      }
+      if (depth >= SYMLINK_MAX_DEPTH) {
+        throw new Error(`"${p}": too many levels of symbolic links (>${SYMLINK_MAX_DEPTH})`);
+      }
+      visited.add(link);
+      return this.getFile(link, followLinks, depth + 1, visited);
     } else {
       return info;
     }

--- a/test/filesystem-spec.ts
+++ b/test/filesystem-spec.ts
@@ -3,7 +3,7 @@ import { wrappedFs as fs } from '../src/wrapped-fs.js';
 import path from 'node:path';
 import { createSymlinkedApp } from './util/createSymlinkedApp.js';
 import { TEST_APPS_DIR } from './util/constants.js';
-import { Filesystem } from '../src/filesystem.js';
+import { Filesystem, FilesystemEntry } from '../src/filesystem.js';
 import {
   createPackage,
   createPackageWithOptions,
@@ -85,6 +85,147 @@ describe('filesystem', () => {
       await createPackage(src, dest);
       const extractPath = path.join(...parts, 'file.txt');
       expect(extractFile(dest, extractPath).toString()).toBe('deep');
+    });
+  });
+
+  describe('symlink recursion protection', () => {
+    function createFilesystemWithHeader(header: FilesystemEntry): Filesystem {
+      const filesystem = new Filesystem('/tmp/fake-asar');
+      filesystem.setHeader(header, 0);
+      return filesystem;
+    }
+
+    it('should detect direct circular symlink (A → B → A) in getFile', () => {
+      // dirA/fileA is a symlink to dirB/fileB, and dirB/fileB is a symlink to dirA/fileA
+      const header: FilesystemEntry = {
+        files: {
+          dirA: {
+            files: {
+              fileA: { link: 'dirB/fileB' },
+            },
+          },
+          dirB: {
+            files: {
+              fileB: { link: 'dirA/fileA' },
+            },
+          },
+        },
+      };
+      const filesystem = createFilesystemWithHeader(header);
+      expect(() => filesystem.getFile('dirA/fileA')).toThrow(/circular symlink detected/);
+    });
+
+    it('should detect circular symlink chain (A → B → C → A) in getFile', () => {
+      const header: FilesystemEntry = {
+        files: {
+          dirA: {
+            files: {
+              fileA: { link: 'dirB/fileB' },
+            },
+          },
+          dirB: {
+            files: {
+              fileB: { link: 'dirC/fileC' },
+            },
+          },
+          dirC: {
+            files: {
+              fileC: { link: 'dirA/fileA' },
+            },
+          },
+        },
+      };
+      const filesystem = createFilesystemWithHeader(header);
+      expect(() => filesystem.getFile('dirA/fileA')).toThrow(/circular symlink detected/);
+    });
+
+    it('should detect self-referencing symlink in getFile', () => {
+      const header: FilesystemEntry = {
+        files: {
+          dir: {
+            files: {
+              file: { link: 'dir/file' },
+            },
+          },
+        },
+      };
+      const filesystem = createFilesystemWithHeader(header);
+      expect(() => filesystem.getFile('dir/file')).toThrow(/circular symlink detected/);
+    });
+
+    it('should detect circular symlink in getNode via directory link', () => {
+      // A directory that is a symlink creating a cycle
+      const header: FilesystemEntry = {
+        files: {
+          dirA: { link: 'dirB' },
+          dirB: { link: 'dirA' },
+        },
+      };
+      const filesystem = createFilesystemWithHeader(header);
+      expect(() => filesystem.getNode('dirA/somefile')).toThrow(
+        /circular symlink detected|too many levels of symbolic links/,
+      );
+    });
+
+    it('should enforce max symlink depth limit in getFile', () => {
+      // Build a chain of 50 symlinks: file0 → file1 → file2 → ... → file49 → file50 (not a link)
+      // This exceeds the 40 depth limit
+      const files: Record<string, any> = {};
+      for (let i = 0; i < 50; i++) {
+        files[`file${i}`] = { link: `file${i + 1}` };
+      }
+      files['file50'] = {
+        unpacked: false,
+        executable: false,
+        offset: '0',
+        size: 10,
+        integrity: { algorithm: 'SHA256', hash: 'abc', blockSize: 0, blocks: [] },
+      };
+      const header: FilesystemEntry = { files };
+      const filesystem = createFilesystemWithHeader(header);
+      expect(() => filesystem.getFile('file0')).toThrow(/too many levels of symbolic links/);
+    });
+
+    it('should resolve symlinks within the depth limit', () => {
+      // Build a chain of 5 symlinks: file0 → file1 → ... → file5 (real file)
+      const files: Record<string, any> = {};
+      for (let i = 0; i < 5; i++) {
+        files[`file${i}`] = { link: `file${i + 1}` };
+      }
+      files['file5'] = {
+        unpacked: false,
+        executable: false,
+        offset: '0',
+        size: 10,
+        integrity: { algorithm: 'SHA256', hash: 'abc', blockSize: 0, blocks: [] },
+      };
+      const header: FilesystemEntry = { files };
+      const filesystem = createFilesystemWithHeader(header);
+      const result = filesystem.getFile('file0');
+      expect(result).toBeDefined();
+      expect('size' in result).toBe(true);
+    });
+
+    it('should not follow symlinks when followLinks is false', () => {
+      const header: FilesystemEntry = {
+        files: {
+          dirA: {
+            files: {
+              fileA: { link: 'dirB/fileB' },
+            },
+          },
+          dirB: {
+            files: {
+              fileB: { link: 'dirA/fileA' },
+            },
+          },
+        },
+      };
+      const filesystem = createFilesystemWithHeader(header);
+      // Should not throw because we're not following links
+      const result = filesystem.getFile('dirA/fileA', false);
+      expect(result).toBeDefined();
+      expect('link' in result).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary
This PR adds protection against circular symlinks and excessive symlink depth in the filesystem module. It prevents infinite loops when resolving symlinks by tracking visited paths and enforcing a maximum recursion depth limit.

## Key Changes
- Added `SYMLINK_MAX_DEPTH` constant set to 40 (matching Linux's `SYMLOOP_MAX`) to limit symlink resolution depth
- Enhanced `getNode()` method with circular symlink detection using a `visited` set and depth tracking
- Enhanced `getFile()` method with the same circular symlink detection and depth limit enforcement
- Both methods now throw descriptive errors when circular symlinks are detected or depth limits are exceeded
- Added comprehensive test suite covering:
  - Direct circular symlinks (A → B → A)
  - Circular symlink chains (A → B → C → A)
  - Self-referencing symlinks
  - Directory symlink cycles
  - Depth limit enforcement (50-link chain exceeding 40-link limit)
  - Valid symlink resolution within depth limits
  - Behavior when `followLinks` is false (symlinks not followed)

## Implementation Details
- The `visited` set tracks resolved paths to detect cycles before they cause infinite recursion
- Depth counter increments with each symlink resolution, throwing an error when it reaches `SYMLINK_MAX_DEPTH`
- Both `getNode()` and `getFile()` maintain separate tracking for their respective resolution paths
- Error messages clearly indicate whether the issue is a circular symlink or excessive depth
- The `followLinks` parameter continues to work as expected, allowing callers to retrieve symlink entries without resolution

https://claude.ai/code/session_01EakT1tL7rQvYhUiYjmKWm6